### PR TITLE
Feature/pixel matrix

### DIFF
--- a/src/image.h
+++ b/src/image.h
@@ -4,15 +4,9 @@
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_image.h>
 
-typedef enum ImageType
-{
-    RGB,
-    GRAYSCALED,
-    BW
-} ImageType;
+typedef enum ImageType { RGB, GRAYSCALED, BW } ImageType;
 
-typedef struct Image
-{
+typedef struct Image {
     SDL_Surface *surface;
     int width, height;
     ImageType imageType;
@@ -20,9 +14,8 @@ typedef struct Image
     Uint8 *bitmap;
 } Image;
 
-
 Image loadImage(const char *path);
-void displayImage(Image *image); 
+void displayImage(Image *image);
 void grayscaleImage(Image *image);
 void blackAndWhite(Image *image);
 


### PR DESCRIPTION
## Nouveautés

Remplisage d'une matrice representant les pixels noirs (1) et blancs (0), stockée en tant que `Uint8 *bitmap` dans la structure `Image`. On la remplit uniquement après avoir obtenu une image en noir et blanc pour simplifier son fonctionnement.

## Remarque

Merge en utilisant l'argument `--squash` car commit useless et c'est plus propre. Merci _**Lowenou**_ :heart:  :kissing_heart: :heart_eyes: